### PR TITLE
Add end-to-end document processing stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+node_modules/
+web/node_modules/
+.env
+*.sqlite
+.data

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: api worker web registry seed develop
+
+api:
+	uvicorn api.app.main:app --reload --host 0.0.0.0 --port 8000
+
+worker:
+	python -m worker.src.worker
+
+web:
+	cd web && npm install && npm run dev -- --host 0.0.0.0 --port 5173
+
+registry:
+	python -m http.server 9000 --directory data/state
+
+seed:
+	python scripts/seed_master_data.py
+
+develop: seed
+	@echo "Run 'make api', 'make worker' and 'make web' in separate terminals."

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-"# cne-poc" 
+# CNE POC Platform
+
+This repository contains a full-stack proof of concept for processing Conselho Nacional de Educação (CNE) documents.
+
+## Services
+
+- **API**: FastAPI backend providing job intake, preview, download, approval, master-data, and model metadata endpoints.
+- **Worker**: Background processor that executes the OCR → layout → segmentation → extraction → normalization → validation → CSV pipeline.
+- **Web**: React dashboard for uploading documents, reviewing previews, downloading CSV outputs, approving jobs, and inspecting history.
+- **Registry**: Lightweight HTTP server exposing model registry artifacts.
+- **ML Stack**: Utilities for training, promoting, and generating synthetic datasets from approved jobs.
+
+## Quick start
+
+```bash
+make develop  # seeds master data
+make api      # start FastAPI on :8000
+make worker   # start queue worker
+make web      # start React dev server on :5173
+```
+
+Alternatively, run everything via Docker:
+
+```bash
+docker-compose up --build
+```
+
+## Data directories
+
+- `data/incoming/<job_id>/`: raw uploads
+- `data/processed/<job_id>/`: preview JSON and UTF-8 CSV outputs
+- `data/master/`: master data managed through the API
+- `data/state/`: job state, queue, and model registry artifacts
+
+## Scripts
+
+- `scripts/seed_master_data.py`: populate baseline master-data records
+
+## Testing
+
+This proof-of-concept focuses on local workflows. Add your preferred test framework (e.g. pytest, vitest) as needed.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY api ./api
+COPY worker ./worker
+COPY ml ./ml
+COPY data ./data
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application package."""

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,0 +1,41 @@
+import logging
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routers import jobs, preview, downloads, approval, master_data, model_metadata
+from .services.metrics import MetricsService
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+app = FastAPI(title="CNE Processing API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+metrics = MetricsService.get_instance()
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    metrics.set_gauge("api.startup", 1)
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    metrics.set_gauge("api.startup", 0)
+
+app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
+app.include_router(preview.router, prefix="/preview", tags=["preview"])
+app.include_router(downloads.router, prefix="/download", tags=["download"])
+app.include_router(approval.router, prefix="/approval", tags=["approval"])
+app.include_router(master_data.router, prefix="/master-data", tags=["master-data"])
+app.include_router(model_metadata.router, prefix="/models", tags=["models"])
+
+
+@app.get("/health", tags=["health"])
+async def healthcheck() -> dict[str, str]:
+    metrics.increment("api.healthcheck")
+    return {"status": "ok"}

--- a/api/app/routers/__init__.py
+++ b/api/app/routers/__init__.py
@@ -1,0 +1,10 @@
+from . import jobs, preview, downloads, approval, master_data, model_metadata
+
+__all__ = [
+    "jobs",
+    "preview",
+    "downloads",
+    "approval",
+    "master_data",
+    "model_metadata",
+]

--- a/api/app/routers/approval.py
+++ b/api/app/routers/approval.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from ..schemas import ApprovalRequest, ApprovalResponse
+from ..services.jobs import JobService
+
+router = APIRouter()
+service = JobService()
+
+
+@router.post("/{job_id}", response_model=ApprovalResponse)
+async def approve_job(job_id: str, payload: ApprovalRequest) -> ApprovalResponse:
+    try:
+        job = service.approve(job_id, approver=payload.approver, notes=payload.notes)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Job not found") from exc
+    return ApprovalResponse(
+        job_id=job.job_id,
+        approved=True,
+        approved_at=job.approved_at or "",
+        notes=payload.notes,
+    )

--- a/api/app/routers/downloads.py
+++ b/api/app/routers/downloads.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from ..services.jobs import PROCESSED_DIR
+
+router = APIRouter()
+
+
+@router.get("/{job_id}")
+async def download_csv(job_id: str) -> FileResponse:
+    csv_path = PROCESSED_DIR / job_id / "output.csv"
+    if not csv_path.exists():
+        raise HTTPException(status_code=404, detail="CSV not available")
+    return FileResponse(csv_path, media_type="text/csv", filename=f"{job_id}.csv")

--- a/api/app/routers/jobs.py
+++ b/api/app/routers/jobs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from ..schemas import JobCreate, JobDetail, JobList
+from ..services.jobs import INCOMING_DIR, JobService
+
+LOGGER = logging.getLogger(__name__)
+
+router = APIRouter()
+job_service = JobService()
+
+
+@router.get("/", response_model=JobList)
+async def list_jobs() -> JobList:
+    return job_service.list_jobs()
+
+
+@router.post("/", response_model=JobDetail)
+async def create_job(
+    file: UploadFile = File(...),
+    uploader: str | None = Form(default=None),
+) -> JobDetail:
+    job = job_service.create(JobCreate(filename=file.filename, uploader=uploader))
+    target_dir = INCOMING_DIR / job.job_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_file = target_dir / file.filename
+    contents = await file.read()
+    target_file.write_bytes(contents)
+    LOGGER.info("Stored upload for job %s at %s", job.job_id, target_file)
+    job_service.enqueue(job)
+    return job
+
+
+@router.get("/{job_id}", response_model=JobDetail)
+async def get_job(job_id: str) -> JobDetail:
+    try:
+        return job_service.get(job_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Job not found") from exc

--- a/api/app/routers/master_data.py
+++ b/api/app/routers/master_data.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from ..schemas import MasterDataResponse, MasterRecord
+from ..services.master_data import MasterDataService
+
+router = APIRouter()
+service = MasterDataService()
+
+
+@router.get("/", response_model=MasterDataResponse)
+async def list_master_data() -> MasterDataResponse:
+    return service.list_records()
+
+
+@router.post("/", response_model=MasterRecord)
+async def upsert_master_record(record: MasterRecord) -> MasterRecord:
+    service.upsert(record)
+    return record

--- a/api/app/routers/model_metadata.py
+++ b/api/app/routers/model_metadata.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from ml.registry import ModelRegistry
+
+from ..schemas import ModelHistoryResponse
+
+router = APIRouter()
+registry = ModelRegistry()
+
+
+@router.get("/history", response_model=ModelHistoryResponse)
+async def history() -> ModelHistoryResponse:
+    return registry.history()

--- a/api/app/routers/preview.py
+++ b/api/app/routers/preview.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, HTTPException
+
+from ..schemas import PreviewResponse
+from ..services.jobs import PROCESSED_DIR
+
+router = APIRouter()
+
+
+@router.get("/{job_id}", response_model=PreviewResponse)
+async def get_preview(job_id: str) -> PreviewResponse:
+    preview_path = PROCESSED_DIR / job_id / "preview.json"
+    if not preview_path.exists():
+        raise HTTPException(status_code=404, detail="Preview not available")
+    data = json.loads(preview_path.read_text(encoding="utf-8"))
+    return PreviewResponse(**data)

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -1,0 +1,29 @@
+from .job import JobCreate, JobDetail, JobList, JobStatus, JobSummary
+from .preview import (
+    ApprovalRequest,
+    ApprovalResponse,
+    CsvDownload,
+    MasterDataResponse,
+    ModelHistoryResponse,
+    ModelMetadata,
+    PreviewResponse,
+    PreviewRow,
+    ValidationBadge,
+)
+
+__all__ = [
+    "JobCreate",
+    "JobDetail",
+    "JobList",
+    "JobStatus",
+    "JobSummary",
+    "PreviewResponse",
+    "PreviewRow",
+    "ValidationBadge",
+    "CsvDownload",
+    "ApprovalRequest",
+    "ApprovalResponse",
+    "MasterDataResponse",
+    "ModelHistoryResponse",
+    "ModelMetadata",
+]

--- a/api/app/schemas/job.py
+++ b/api/app/schemas/job.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class JobStatus(str, Enum):
+    RECEIVED = "received"
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    APPROVED = "approved"
+
+
+class JobCreate(BaseModel):
+    filename: str
+    uploader: Optional[str] = Field(default=None, description="Name or identifier of the uploader")
+
+
+class JobSummary(BaseModel):
+    job_id: str
+    status: JobStatus
+    filename: str
+    created_at: datetime
+    updated_at: datetime
+    error: Optional[str] = None
+
+
+class JobDetail(JobSummary):
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    preview_ready: bool = False
+    csv_ready: bool = False
+    approved_at: Optional[datetime] = None
+
+
+class JobList(BaseModel):
+    jobs: list[JobSummary]

--- a/api/app/schemas/preview.py
+++ b/api/app/schemas/preview.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ValidationBadge(BaseModel):
+    field: str
+    status: str
+    message: str | None = None
+
+
+class PreviewRow(BaseModel):
+    columns: list[str]
+    validations: list[ValidationBadge] = Field(default_factory=list)
+
+
+class PreviewResponse(BaseModel):
+    job_id: str
+    headers: list[str]
+    rows: list[PreviewRow]
+    total_rows: int
+
+
+class CsvDownload(BaseModel):
+    job_id: str
+    url: str
+
+
+class ApprovalRequest(BaseModel):
+    approver: str
+    notes: str | None = None
+
+
+class ApprovalResponse(BaseModel):
+    job_id: str
+    approved: bool
+    approved_at: str
+    notes: str | None = None
+
+
+class MasterRecord(BaseModel):
+    sigla: str
+    descricao: str
+    codigo: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MasterDataResponse(BaseModel):
+    records: list[MasterRecord]
+
+
+class ModelMetadata(BaseModel):
+    model_name: str
+    version: str
+    created_at: str
+    status: str
+    metrics: dict[str, Any]
+
+
+class ModelHistoryResponse(BaseModel):
+    items: list[ModelMetadata]

--- a/api/app/services/jobs.py
+++ b/api/app/services/jobs.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ..schemas import JobCreate, JobDetail, JobList, JobStatus, JobSummary
+from .metrics import MetricsService
+
+LOGGER = logging.getLogger(__name__)
+STATE_FILE = Path("data/state/jobs.json")
+QUEUE_FILE = Path("data/state/queue.jsonl")
+INCOMING_DIR = Path("data/incoming")
+PROCESSED_DIR = Path("data/processed")
+
+for directory in (STATE_FILE.parent, INCOMING_DIR, PROCESSED_DIR):
+    directory.mkdir(parents=True, exist_ok=True)
+
+
+class JobService:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._metrics = MetricsService.get_instance()
+        self._state: dict[str, dict[str, Any]] = {}
+        if STATE_FILE.exists():
+            self._state = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+
+    def _persist(self) -> None:
+        STATE_FILE.write_text(json.dumps(self._state, indent=2, default=str), encoding="utf-8")
+
+    def create(self, payload: JobCreate) -> JobDetail:
+        job_id = uuid.uuid4().hex
+        now = datetime.utcnow().isoformat()
+        record = {
+            "job_id": job_id,
+            "status": JobStatus.RECEIVED.value,
+            "filename": payload.filename,
+            "created_at": now,
+            "updated_at": now,
+            "metadata": {"uploader": payload.uploader},
+            "preview_ready": False,
+            "csv_ready": False,
+            "error": None,
+            "approved_at": None,
+        }
+        with self._lock:
+            self._state[job_id] = record
+            self._persist()
+        self._metrics.increment("jobs.created")
+        LOGGER.info("Job %s received", job_id, extra={"job_id": job_id, "status": record["status"]})
+        return JobDetail(**record)
+
+    def list_jobs(self) -> JobList:
+        with self._lock:
+            jobs = [JobSummary(**data) for data in self._state.values()]
+        jobs.sort(key=lambda job: job.created_at, reverse=True)
+        return JobList(jobs=jobs)
+
+    def get(self, job_id: str) -> JobDetail:
+        with self._lock:
+            data = self._state.get(job_id)
+        if not data:
+            raise KeyError(job_id)
+        return JobDetail(**data)
+
+    def update_status(self, job_id: str, status: JobStatus, **updates: Any) -> JobDetail:
+        with self._lock:
+            if job_id not in self._state:
+                raise KeyError(job_id)
+            record = self._state[job_id]
+            record.update(updates)
+            record["status"] = status.value
+            record["updated_at"] = datetime.utcnow().isoformat()
+            self._persist()
+        LOGGER.info("Job %s status -> %s", job_id, status.value, extra={"job_id": job_id, "status": status.value})
+        return JobDetail(**record)
+
+    def mark_preview_ready(self, job_id: str) -> None:
+        self.update_status(job_id, JobStatus.COMPLETED, preview_ready=True, csv_ready=True)
+
+    def mark_failed(self, job_id: str, error: str) -> None:
+        self.update_status(job_id, JobStatus.FAILED, error=error)
+
+    def approve(self, job_id: str, approver: str, notes: str | None = None) -> JobDetail:
+        detail = self.get(job_id)
+        updated = self.update_status(
+            job_id,
+            JobStatus.APPROVED,
+            approved_at=datetime.utcnow().isoformat(),
+            metadata={**detail.metadata, "approved_by": approver, "notes": notes},
+        )
+        self._metrics.increment("jobs.approved")
+        return updated
+
+    def record_error(self, job_id: str, error: str) -> None:
+        LOGGER.error("Job %s failed: %s", job_id, error, extra={"job_id": job_id, "error": error})
+        self.mark_failed(job_id, error)
+
+    def enqueue(self, job: JobDetail) -> None:
+        payload = {
+            "job_id": job.job_id,
+            "filename": job.filename,
+            "received_at": job.created_at,
+        }
+        with QUEUE_FILE.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload) + "\n")
+        self.update_status(job.job_id, JobStatus.QUEUED)
+        self._metrics.increment("jobs.queued")
+        LOGGER.info("Job %s enqueued", job.job_id, extra={"job_id": job.job_id})
+
+    def set_processing(self, job_id: str) -> None:
+        self.update_status(job_id, JobStatus.PROCESSING)
+        self._metrics.increment("jobs.processing")
+
+    def set_completed(self, job_id: str) -> None:
+        self.update_status(job_id, JobStatus.COMPLETED, preview_ready=True, csv_ready=True)
+        self._metrics.increment("jobs.completed")

--- a/api/app/services/master_data.py
+++ b/api/app/services/master_data.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from ..schemas import MasterDataResponse, MasterRecord
+
+LOGGER = logging.getLogger(__name__)
+
+DATA_DIR = Path("data/master")
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+class MasterDataService:
+    def __init__(self, directory: Path | None = None) -> None:
+        self._directory = directory or DATA_DIR
+
+    def _load_files(self) -> Iterable[Path]:
+        return sorted(self._directory.glob("*.json"))
+
+    def list_records(self) -> MasterDataResponse:
+        records: list[MasterRecord] = []
+        for file in self._load_files():
+            try:
+                data = json.loads(file.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    for item in data:
+                        records.append(MasterRecord(**item))
+                elif isinstance(data, dict):
+                    records.append(MasterRecord(**data))
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.exception("Failed to load master data from %s", file)
+                raise exc
+        return MasterDataResponse(records=records)
+
+    def upsert(self, record: MasterRecord) -> None:
+        file = self._directory / f"{record.sigla.lower()}.json"
+        file.write_text(record.json(indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def bulk_load(self, records: Iterable[MasterRecord]) -> None:
+        for record in records:
+            self.upsert(record)

--- a/api/app/services/metrics.py
+++ b/api/app/services/metrics.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from typing import Dict
+
+
+class MetricsService:
+    _instance: "MetricsService" | None = None
+    _lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._counters: Dict[str, int] = defaultdict(int)
+        self._gauges: Dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "MetricsService":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def increment(self, name: str, value: int = 1) -> None:
+        with self._lock:
+            self._counters[name] += value
+
+    def get_counter(self, name: str) -> int:
+        with self._lock:
+            return self._counters[name]
+
+    def set_gauge(self, name: str, value: float) -> None:
+        with self._lock:
+            self._gauges[name] = value
+
+    def get_gauge(self, name: str) -> float:
+        with self._lock:
+            return self._gauges.get(name, 0.0)
+
+    def snapshot(self) -> dict[str, float | int]:
+        with self._lock:
+            data = {**self._counters, **self._gauges}
+        return data

--- a/data/master/default.json
+++ b/data/master/default.json
@@ -1,0 +1,18 @@
+[
+  {
+    "sigla": "MEC",
+    "descricao": "Ministério da Educação",
+    "codigo": "001",
+    "metadata": {
+      "uf": "BR"
+    }
+  },
+  {
+    "sigla": "INEP",
+    "descricao": "Instituto Nacional de Estudos e Pesquisas Educacionais",
+    "codigo": "002",
+    "metadata": {
+      "uf": "BR"
+    }
+  }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    ports:
+      - '8000:8000'
+    volumes:
+      - ./data:/app/data
+    environment:
+      - PYTHONUNBUFFERED=1
+
+  worker:
+    build:
+      context: .
+      dockerfile: worker/Dockerfile
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - api
+
+  web:
+    build:
+      context: web
+      dockerfile: Dockerfile
+    ports:
+      - '5173:5173'
+    environment:
+      - VITE_API_BASE=/api
+    depends_on:
+      - api
+
+  registry:
+    image: python:3.11-slim
+    working_dir: /app
+    command: python -m http.server 9000 --directory /app/data/state
+    volumes:
+      - ./data:/app/data
+    ports:
+      - '9000:9000'

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,1 @@
+"""Machine learning orchestration package."""

--- a/ml/promotion.py
+++ b/ml/promotion.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from statistics import mean
+from typing import List
+
+from .registry import ModelRegistry
+from .training import build_training_corpus
+
+
+def _score_dataset(rows: List[dict[str, str]]) -> float:
+    lengths = [len(row.get("descricao", "")) for row in rows]
+    return mean(lengths) if lengths else 0.0
+
+
+def evaluate_and_promote(candidate_version: str) -> None:
+    registry = ModelRegistry()
+    rows = build_training_corpus()
+    score = _score_dataset(rows)
+    registry.promote(candidate_version)
+    registry.update_metrics(candidate_version, {"dataset_score": score})
+
+
+def rollback(version: str) -> None:
+    registry = ModelRegistry()
+    registry.rollback(version)

--- a/ml/registry.py
+++ b/ml/registry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+from api.app.schemas import ModelHistoryResponse, ModelMetadata
+
+REGISTRY_FILE = Path("data/state/model_registry.json")
+REGISTRY_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _load_history() -> List[dict]:
+    if not REGISTRY_FILE.exists():
+        return []
+    return json.loads(REGISTRY_FILE.read_text(encoding="utf-8"))
+
+
+def _save_history(history: Iterable[dict]) -> None:
+    REGISTRY_FILE.write_text(json.dumps(list(history), indent=2), encoding="utf-8")
+
+
+@dataclass
+class ModelRecord:
+    model_name: str
+    version: str
+    created_at: str
+    status: str
+    metrics: dict
+
+
+class ModelRegistry:
+    def __init__(self) -> None:
+        self._history = _load_history()
+
+    def register(self, model_name: str, metrics: dict, status: str = "candidate") -> ModelRecord:
+        version = f"{len(self._history) + 1:03d}"
+        record = ModelRecord(
+            model_name=model_name,
+            version=version,
+            created_at=datetime.utcnow().isoformat(),
+            status=status,
+            metrics=metrics,
+        )
+        self._history.append(asdict(record))
+        _save_history(self._history)
+        return record
+
+    def promote(self, version: str) -> None:
+        for record in self._history:
+            record["status"] = "archived" if record["version"] != version else "production"
+        _save_history(self._history)
+
+    def rollback(self, version: str) -> None:
+        for record in self._history:
+            if record["version"] == version:
+                record["status"] = "production"
+            elif record["status"] == "production":
+                record["status"] = "archived"
+        _save_history(self._history)
+
+    def update_metrics(self, version: str, metrics: dict) -> None:
+        for record in self._history:
+            if record["version"] == version:
+                record.setdefault("metrics", {}).update(metrics)
+        _save_history(self._history)
+
+    def history(self) -> ModelHistoryResponse:
+        items = [ModelMetadata(**record) for record in self._history]
+        return ModelHistoryResponse(items=items)

--- a/ml/synthetic.py
+++ b/ml/synthetic.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import random
+from typing import List
+from api.app.services.master_data import MasterDataService
+
+from .training import build_training_corpus
+
+
+def generate_synthetic_dataset(multiplier: int = 2) -> List[dict[str, str]]:
+    master_service = MasterDataService()
+    master_records = master_service.list_records().records
+    base_rows = build_training_corpus()
+    synthetic: List[dict[str, str]] = []
+    for _ in range(multiplier):
+        for row in base_rows:
+            record = row.copy()
+            if master_records:
+                match = random.choice(master_records)
+                record["sigla"] = match.sigla
+                record["orgao"] = match.descricao
+            record["observacao"] = "synthetic"
+            synthetic.append(record)
+    return synthetic

--- a/ml/training.py
+++ b/ml/training.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import List
+
+from ml.registry import ModelRegistry
+
+JOBS_FILE = Path("data/state/jobs.json")
+PROCESSED_DIR = Path("data/processed")
+
+
+def _approved_jobs() -> List[str]:
+    if not JOBS_FILE.exists():
+        return []
+    data = json.loads(JOBS_FILE.read_text(encoding="utf-8"))
+    return [job_id for job_id, record in data.items() if record.get("status") == "approved"]
+
+
+def _load_rows(job_id: str) -> List[dict[str, str]]:
+    csv_path = PROCESSED_DIR / job_id / "output.csv"
+    if not csv_path.exists():
+        return []
+    with csv_path.open(encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
+
+
+def build_training_corpus() -> List[dict[str, str]]:
+    rows: List[dict[str, str]] = []
+    for job_id in _approved_jobs():
+        rows.extend(_load_rows(job_id))
+    return rows
+
+
+def train(model_name: str = "baseline") -> None:
+    registry = ModelRegistry()
+    rows = build_training_corpus()
+    metrics = {
+        "rows": len(rows),
+        "unique_siglas": len({row.get("sigla") for row in rows if row.get("sigla")}),
+    }
+    registry.register(model_name=model_name, metrics=metrics)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+pydantic==1.10.14
+python-multipart==0.0.6

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MASTER_DIR = Path('data/master')
+MASTER_DIR.mkdir(parents=True, exist_ok=True)
+
+seed = [
+    {
+        'sigla': 'MEC',
+        'descricao': 'Ministério da Educação',
+        'codigo': '001',
+        'metadata': {'uf': 'BR'},
+    },
+    {
+        'sigla': 'INEP',
+        'descricao': 'Instituto Nacional de Estudos e Pesquisas Educacionais',
+        'codigo': '002',
+        'metadata': {'uf': 'BR'},
+    },
+]
+
+(MASTER_DIR / 'default.json').write_text(json.dumps(seed, indent=2, ensure_ascii=False), encoding='utf-8')
+print('Seeded master data with', len(seed), 'records')

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CNE Processamento</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cne-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,25 @@
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
+function App() {
+  const location = useLocation();
+  return (
+    <div className="app">
+      <header className="app__header">
+        <h1>CNE Processamento</h1>
+        <nav>
+          <Link to="/" className={location.pathname === '/' ? 'active' : ''}>
+            Upload
+          </Link>
+          <Link to="/history" className={location.pathname.includes('history') ? 'active' : ''}>
+            Histórico
+          </Link>
+        </nav>
+      </header>
+      <main className="app__main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+const baseURL = (import.meta as any).env?.VITE_API_BASE ?? '/api';
+axios.defaults.baseURL = baseURL;
+
+export default axios;

--- a/web/src/components/PreviewTable.tsx
+++ b/web/src/components/PreviewTable.tsx
@@ -1,0 +1,48 @@
+import ValidationIcon from './ValidationIcon';
+
+export interface PreviewRow {
+  columns: string[];
+  validations: { field: string; status: string; message?: string | null }[];
+}
+
+interface PreviewTableProps {
+  headers: string[];
+  rows: PreviewRow[];
+}
+
+const PreviewTable = ({ headers, rows }: PreviewTableProps) => {
+  return (
+    <div className="card">
+      <table className="table">
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header}>{header}</th>
+            ))}
+            <th>Validações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              {row.columns.map((value, columnIndex) => (
+                <td key={`${index}-${columnIndex}`}>{value}</td>
+              ))}
+              <td>
+                {row.validations.map((validation) => (
+                  <ValidationIcon
+                    key={validation.field}
+                    status={validation.status}
+                    message={validation.message}
+                  />
+                ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PreviewTable;

--- a/web/src/components/SummaryTiles.tsx
+++ b/web/src/components/SummaryTiles.tsx
@@ -1,0 +1,16 @@
+interface SummaryTilesProps {
+  items: { label: string; value: string | number }[];
+}
+
+const SummaryTiles = ({ items }: SummaryTilesProps) => (
+  <div className="summary-grid">
+    {items.map((item) => (
+      <div key={item.label} className="summary-tile">
+        <h3>{item.label}</h3>
+        <p>{item.value}</p>
+      </div>
+    ))}
+  </div>
+);
+
+export default SummaryTiles;

--- a/web/src/components/UploadDropzone.tsx
+++ b/web/src/components/UploadDropzone.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+
+interface UploadDropzoneProps {
+  onUpload: (file: File) => Promise<void>;
+  disabled?: boolean;
+}
+
+const UploadDropzone = ({ onUpload, disabled }: UploadDropzoneProps) => {
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || !files[0]) return;
+      setError(null);
+      try {
+        await onUpload(files[0]);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    },
+    [onUpload],
+  );
+
+  return (
+    <div
+      className={`card upload-dropzone ${dragging ? 'dragging' : ''} ${disabled ? 'disabled' : ''}`}
+      onDragOver={(event) => {
+        event.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(event) => {
+        event.preventDefault();
+        setDragging(false);
+        if (!disabled) {
+          handleFiles(event.dataTransfer.files);
+        }
+      }}
+    >
+      <input
+        id="upload-input"
+        type="file"
+        style={{ display: 'none' }}
+        onChange={(event) => handleFiles(event.target.files)}
+        disabled={disabled}
+      />
+      <label htmlFor="upload-input" className="upload-label">
+        <strong>Arraste e solte</strong> ou clique para selecionar um arquivo
+      </label>
+      {error && <p className="error">{error}</p>}
+    </div>
+  );
+};
+
+export default UploadDropzone;

--- a/web/src/components/ValidationIcon.tsx
+++ b/web/src/components/ValidationIcon.tsx
@@ -1,0 +1,11 @@
+interface ValidationIconProps {
+  status: string;
+  message?: string | null;
+}
+
+const ValidationIcon = ({ status, message }: ValidationIconProps) => {
+  const className = status === 'ok' ? 'badge ok' : 'badge warning';
+  return <span className={className} title={message ?? undefined}>{status.toUpperCase()}</span>;
+};
+
+export default ValidationIcon;

--- a/web/src/hooks/useJobs.ts
+++ b/web/src/hooks/useJobs.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import axios from '../api';
+
+export interface JobSummary {
+  job_id: string;
+  status: string;
+  filename: string;
+  created_at: string;
+  updated_at: string;
+  error?: string | null;
+}
+
+export interface JobDetail extends JobSummary {
+  preview_ready: boolean;
+  csv_ready: boolean;
+  metadata: Record<string, unknown>;
+}
+
+const useJobs = () => {
+  const [jobs, setJobs] = useState<JobSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await axios.get<{ jobs: JobSummary[] }>('/jobs/');
+      setJobs(response.data.jobs);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { jobs, loading, refresh };
+};
+
+export default useJobs;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+import App from './App';
+import UploadPage from './pages/UploadPage';
+import ResultPage from './pages/ResultPage';
+import HistoryPage from './pages/HistoryPage';
+
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />}>
+          <Route index element={<UploadPage />} />
+          <Route path="jobs/:jobId" element={<ResultPage />} />
+          <Route path="history" element={<HistoryPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+import useJobs from '../hooks/useJobs';
+import axios from '../api';
+
+interface ModelMetadata {
+  model_name: string;
+  version: string;
+  created_at: string;
+  status: string;
+  metrics: Record<string, unknown>;
+}
+
+const HistoryPage = () => {
+  const { jobs, refresh } = useJobs();
+  const [models, setModels] = useState<ModelMetadata[]>([]);
+
+  useEffect(() => {
+    refresh();
+    const loadModels = async () => {
+      const response = await axios.get<{ items: ModelMetadata[] }>('/models/history');
+      setModels(response.data.items);
+    };
+    loadModels();
+  }, [refresh]);
+
+  return (
+    <div className="history-page">
+      <div className="card">
+        <h2>Jobs aprovados</h2>
+        <ul>
+          {jobs
+            .filter((job) => job.status === 'approved')
+            .map((job) => (
+              <li key={job.job_id}>
+                {job.filename} - {job.status} em {new Date(job.updated_at).toLocaleString()}
+              </li>
+            ))}
+        </ul>
+      </div>
+      <div className="card">
+        <h2>Histórico de modelos</h2>
+        <ul>
+          {models.map((model) => (
+            <li key={model.version}>
+              {model.model_name} v{model.version} - {model.status} -{' '}
+              {JSON.stringify(model.metrics)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryPage;

--- a/web/src/pages/ResultPage.tsx
+++ b/web/src/pages/ResultPage.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import PreviewTable, { PreviewRow } from '../components/PreviewTable';
+import axios from '../api';
+
+interface PreviewResponse {
+  job_id: string;
+  headers: string[];
+  rows: PreviewRow[];
+  total_rows: number;
+}
+
+const ResultPage = () => {
+  const { jobId } = useParams();
+  const navigate = useNavigate();
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [status, setStatus] = useState<string>('');
+
+  useEffect(() => {
+    const load = async () => {
+      if (!jobId) return;
+      const [jobResponse, previewResponse] = await Promise.all([
+        axios.get(`/jobs/${jobId}`),
+        axios.get(`/preview/${jobId}`).catch(() => null),
+      ]);
+      setStatus(jobResponse.data.status);
+      if (previewResponse) {
+        setPreview(previewResponse.data);
+      }
+    };
+    load();
+  }, [jobId]);
+
+  const handleDownload = () => {
+    if (!jobId) return;
+    window.location.href = `${axios.defaults.baseURL}/download/${jobId}`;
+  };
+
+  const handleApprove = async () => {
+    if (!jobId) return;
+    await axios.post(`/approval/${jobId}`, { approver: 'admin' });
+    navigate('/history');
+  };
+
+  return (
+    <div className="result-page">
+      <div className="card">
+        <h2>Job {jobId}</h2>
+        <p>Status atual: {status}</p>
+        <button onClick={handleDownload} disabled={!preview}>
+          Baixar CSV
+        </button>
+        <button onClick={handleApprove} disabled={status !== 'completed'}>
+          Aprovar
+        </button>
+        <Link to="/">Voltar</Link>
+      </div>
+      {preview && <PreviewTable headers={preview.headers} rows={preview.rows} />}
+    </div>
+  );
+};
+
+export default ResultPage;

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import UploadDropzone from '../components/UploadDropzone';
+import SummaryTiles from '../components/SummaryTiles';
+import useJobs from '../hooks/useJobs';
+import axios from '../api';
+
+const UploadPage = () => {
+  const navigate = useNavigate();
+  const { jobs, refresh } = useJobs();
+  const [uploading, setUploading] = useState(false);
+
+  const handleUpload = async (file: File) => {
+    setUploading(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const response = await axios.post('/jobs/', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      await refresh();
+      navigate(`/jobs/${response.data.job_id}`);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="upload-page">
+      <UploadDropzone onUpload={handleUpload} disabled={uploading} />
+      <SummaryTiles
+        items={[
+          { label: 'Total de Jobs', value: jobs.length },
+          { label: 'Em processamento', value: jobs.filter((job) => job.status === 'processing').length },
+          { label: 'Aprovados', value: jobs.filter((job) => job.status === 'approved').length },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default UploadPage;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,136 @@
+:root {
+  font-family: 'Inter', sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #1f2933;
+  color: #fff;
+}
+
+.app__header nav a {
+  margin-left: 1rem;
+  color: #d9e2ec;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.app__header nav a.active {
+  color: #fff;
+  border-bottom: 2px solid #fff;
+}
+
+.app__main {
+  flex: 1;
+  padding: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid #e4e7eb;
+  text-align: left;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.summary-tile {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge.ok {
+  background: #def7ec;
+  color: #03543f;
+}
+
+.badge.warning {
+  background: #fde8e8;
+  color: #9b1c1c;
+}
+
+.upload-dropzone {
+  border: 2px dashed #94a3b8;
+  padding: 2rem;
+  text-align: center;
+  transition: background 0.2s ease-in-out;
+}
+
+.upload-dropzone.dragging {
+  background: #e0f2fe;
+}
+
+.upload-dropzone.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.upload-label {
+  cursor: pointer;
+  display: inline-block;
+  margin-top: 1rem;
+}
+
+.error {
+  color: #b91c1c;
+  margin-top: 1rem;
+}
+
+.card button {
+  margin-right: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  background: #2563eb;
+  color: #fff;
+}
+
+.card button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      }
+    }
+  }
+});

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY api ./api
+COPY worker ./worker
+COPY data ./data
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "-m", "worker.src.worker"]

--- a/worker/src/__init__.py
+++ b/worker/src/__init__.py
@@ -1,0 +1,1 @@
+"""Worker module entrypoint package."""

--- a/worker/src/csv_writer.py
+++ b/worker/src/csv_writer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from .extract import EXPECTED_COLUMNS
+
+
+def write_csv(job_id: str, records: Iterable[dict[str, str]], base_dir: Path) -> Path:
+    job_dir = base_dir / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = job_dir / "output.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=EXPECTED_COLUMNS)
+        writer.writeheader()
+        for record in records:
+            writer.writerow({key: record.get(key, "") for key in EXPECTED_COLUMNS})
+    return csv_path

--- a/worker/src/extract.py
+++ b/worker/src/extract.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+EXPECTED_COLUMNS = [
+    "orgao",
+    "lista",
+    "tipo",
+    "linha",
+    "descricao",
+    "valor",
+    "sigla",
+    "fonte",
+    "competencia",
+    "observacao",
+]
+
+
+def extract_records(segments: Dict[str, List[dict]]) -> List[dict[str, str]]:
+    records: List[dict[str, str]] = []
+    current: dict[str, str] = {column: "" for column in EXPECTED_COLUMNS}
+    line_number = 1
+    for key, entries in segments.items():
+        for entry in entries:
+            text = entry["content"].strip()
+            if ":" in text:
+                prefix, value = [part.strip() for part in text.split(":", 1)]
+                lowered = prefix.lower()
+                if lowered in current:
+                    current[lowered] = value
+            elif text:
+                current["descricao"] = text
+            current["linha"] = str(line_number)
+            line_number += 1
+            if all(current.get(col) for col in ("orgao", "lista", "tipo")):
+                records.append(current.copy())
+                current = {column: "" for column in EXPECTED_COLUMNS}
+    if any(current.values()):
+        records.append(current)
+    return records

--- a/worker/src/fuzzy.py
+++ b/worker/src/fuzzy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Dict, Tuple
+
+MASTER_DIR = Path("data/master")
+
+
+def _load_master() -> Dict[str, dict]:
+    records: Dict[str, dict] = {}
+    for file in MASTER_DIR.glob("*.json"):
+        data = json.loads(file.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            records[data["sigla"].upper()] = data
+        elif isinstance(data, list):
+            for item in data:
+                records[item["sigla"].upper()] = item
+    return records
+
+
+MASTER_CACHE = _load_master()
+
+
+def match_sigla(sigla: str) -> Tuple[str, dict | None]:
+    upper = sigla.upper()
+    if upper in MASTER_CACHE:
+        return upper, MASTER_CACHE[upper]
+    matches = get_close_matches(upper, MASTER_CACHE.keys(), n=1, cutoff=0.7)
+    if matches:
+        match = matches[0]
+        return match, MASTER_CACHE[match]
+    return upper, None

--- a/worker/src/layout.py
+++ b/worker/src/layout.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+def detect_layout(lines: Iterable[str]) -> List[dict[str, str]]:
+    """Detects layout structures in the OCR lines."""
+
+    layout = []
+    for index, line in enumerate(lines):
+        layout.append({
+            "index": index,
+            "content": line,
+            "section": "header" if index == 0 else "body",
+        })
+    return layout

--- a/worker/src/normalize.py
+++ b/worker/src/normalize.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .fuzzy import match_sigla
+
+NORMALIZED_COLUMNS = [
+    "orgao",
+    "lista",
+    "tipo",
+    "linha",
+    "descricao",
+    "valor",
+    "sigla",
+    "fonte",
+    "competencia",
+    "observacao",
+]
+
+
+def normalize(records: Iterable[dict[str, str]]) -> List[dict[str, str]]:
+    normalized: List[dict[str, str]] = []
+    for record in records:
+        data = {column: record.get(column, "").strip() for column in NORMALIZED_COLUMNS}
+        if data["sigla"]:
+            data["sigla"], metadata = match_sigla(data["sigla"])
+            if metadata:
+                data["observacao"] = metadata.get("descricao", data["observacao"])
+        normalized.append(data)
+    return normalized

--- a/worker/src/ocr.py
+++ b/worker/src/ocr.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+def run_ocr(file_path: Path) -> Iterable[str]:
+    """Perform OCR on the uploaded document.
+
+    This placeholder implementation treats the file as UTF-8 text and
+    returns individual lines. In production this would call a dedicated OCR
+    engine such as Tesseract or a hosted API.
+    """
+
+    text = file_path.read_text(encoding="utf-8", errors="ignore")
+    return [line.strip() for line in text.splitlines() if line.strip()]

--- a/worker/src/pipeline.py
+++ b/worker/src/pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from api.app.schemas import PreviewResponse, PreviewRow
+from api.app.services.jobs import INCOMING_DIR, PROCESSED_DIR, JobService
+from api.app.services.metrics import MetricsService
+
+from . import csv_writer, extract, layout, normalize, ocr, segment, validate
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _first_file(job_dir: Path) -> Path:
+    for file in job_dir.iterdir():
+        if file.is_file():
+            return file
+    raise FileNotFoundError(f"No files found in {job_dir}")
+
+
+def process_job(job_id: str) -> None:
+    job_service = JobService()
+    metrics = MetricsService.get_instance()
+    incoming_dir = INCOMING_DIR / job_id
+    processed_dir = PROCESSED_DIR / job_id
+    try:
+        job_service.set_processing(job_id)
+        file_path = _first_file(incoming_dir)
+        LOGGER.info("Processing job %s from %s", job_id, file_path)
+        lines = list(ocr.run_ocr(file_path))
+        layout_info = layout.detect_layout(lines)
+        segments = segment.segment_lines(layout_info)
+        raw_records = extract.extract_records(segments)
+        normalized_records = normalize.normalize(raw_records)
+        validations = validate.validate(normalized_records)
+        csv_writer.write_csv(job_id, normalized_records, PROCESSED_DIR)
+        preview_rows = [
+            PreviewRow(
+                columns=[record.get(column, "") for column in extract.EXPECTED_COLUMNS],
+                validations=row_badges,
+            )
+            for record, row_badges in zip(normalized_records, validations)
+        ]
+        preview = PreviewResponse(
+            job_id=job_id,
+            headers=extract.EXPECTED_COLUMNS,
+            rows=preview_rows,
+            total_rows=len(preview_rows),
+        )
+        processed_dir.mkdir(parents=True, exist_ok=True)
+        preview_path = processed_dir / "preview.json"
+        preview_path.write_text(preview.json(indent=2, ensure_ascii=False), encoding="utf-8")
+        LOGGER.info("Job %s processed successfully", job_id)
+        job_service.set_completed(job_id)
+        metrics.increment("worker.jobs.completed")
+    except Exception as exc:  # pragma: no cover - defensive flow
+        LOGGER.exception("Job %s failed", job_id)
+        job_service.record_error(job_id, str(exc))
+        metrics.increment("worker.jobs.failed")
+        raise

--- a/worker/src/segment.py
+++ b/worker/src/segment.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+
+SEGMENT_KEYS = ["orgao", "lista", "tipo"]
+
+
+def segment_lines(layout: Iterable[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    segments: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for entry in layout:
+        key = "body"
+        lowered = entry["content"].lower()
+        for segment in SEGMENT_KEYS:
+            if segment in lowered:
+                key = segment
+                break
+        segments[key].append(entry)
+    return dict(segments)

--- a/worker/src/validate.py
+++ b/worker/src/validate.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from api.app.schemas import ValidationBadge
+
+
+REQUIRED_COLUMNS = ["orgao", "lista", "tipo", "sigla"]
+
+
+def validate(records: Iterable[dict[str, str]]) -> List[List[ValidationBadge]]:
+    results: List[List[ValidationBadge]] = []
+    for record in records:
+        badges: List[ValidationBadge] = []
+        for column in REQUIRED_COLUMNS:
+            value = record.get(column, "")
+            if value:
+                badges.append(ValidationBadge(field=column, status="ok", message=None))
+            else:
+                badges.append(ValidationBadge(field=column, status="warning", message="Valor ausente"))
+        results.append(badges)
+    return results

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from api.app.services.jobs import QUEUE_FILE
+
+from .pipeline import process_job
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def _pop_queue() -> list[dict]:
+    if not QUEUE_FILE.exists():
+        return []
+    lines = [line for line in QUEUE_FILE.read_text(encoding="utf-8").splitlines() if line.strip()]
+    QUEUE_FILE.write_text("", encoding="utf-8")
+    return [json.loads(line) for line in lines]
+
+
+def run_forever(poll_interval: float = 2.0) -> None:
+    LOGGER.info("Worker started")
+    while True:
+        jobs = _pop_queue()
+        if not jobs:
+            time.sleep(poll_interval)
+            continue
+        for job in jobs:
+            job_id = job["job_id"]
+            LOGGER.info("Worker picked job %s", job_id)
+            process_job(job_id)
+
+
+if __name__ == "__main__":
+    run_forever()


### PR DESCRIPTION
## Summary
- add FastAPI service with job intake, preview/download, approval, master-data, and model metadata routes
- implement worker pipeline modules for OCR, segmentation, normalization, validation, CSV export, and a polling worker
- build React UI for upload-to-approval workflow plus ML utilities, Dockerfiles, Makefile, and compose setup for local dev

## Testing
- python -m compileall api worker ml scripts

------
https://chatgpt.com/codex/tasks/task_b_68e26a43578c8321b50102567c5d8688