### PR TITLE
Align worker pipeline with 10-column output schema

### DIFF
--- a/samples/golden/example_output.csv
+++ b/samples/golden/example_output.csv
@@ -1,11 +1,6 @@
-orgao,lista,tipo,num_ordem,linha,descricao,valor,sigla,fonte,competencia,observacao,dtmnfr
-"Conselho Nacional de Educação","Lista Unica",TITULAR,1,11,"Representante titular unico",1000,MEC,DOU,2024,"Ministério da Educação",2024-03-15
-"Conselho Nacional de Educação","Lista Unica",TITULAR,2,20,"Segundo titular mesma lista",980,MEC,DOU,2024,"Ministério da Educação",2024-03-15
-"Conselho Nacional de Educação","Coligacao Educação & Cidadania",TITULAR,1,29,"Titular coligacao com simbolos",950,MEC,DOU,2024,"Ministério da Educação",2024-03-15
-"Conselho Nacional de Educação","Lista Unica",SUPLENTE,1,37,"Suplente aguardando confirmacao",0,"",DOU,2024,"OCR incerta",2024-03-15
-"Conselho Nacional de Educação","Grupo GCE § Educação",GCE,1,46,"Grupo consultivo especial",0,GCE,"Memo Nº 10",2024,"Grupo Consultivo Especial",2024-03-15
 DTMNFR;ORGAO;TIPO;SIGLA;SIMBOLO;NOME_LISTA;NUM_ORDEM;NOME_CANDIDATO;PARTIDO_PROPONENTE;INDEPENDENTE
 2024;Conselho Nacional de Educação;2;MEC;;Lista Unica;1;Representante titular unico;Ministério da Educação;S
-2024;Conselho Nacional de Educação;2;INEP;EC;Educação & Cidadania;2;Titular coligacao com simbolos;Instituto Nacional de Estudos e Pesquisas Educacionais;N
+2024;Conselho Nacional de Educação;2;MEC;;Lista Unica;2;Segundo titular mesma lista;Ministério da Educação;S
+2024;Conselho Nacional de Educação;2;MEC;EC;Coligacao Educação & Cidadania;1;Titular coligacao com simbolos;Ministério da Educação;N
 2024;Conselho Nacional de Educação;3;;;Lista Unica;1;Suplente aguardando confirmacao;;S
-2024;Conselho Nacional de Educação;3;GCE;GCE;Educação;2;Grupo consultivo especial;Grupo Consultivo Especial;N
+2024;Conselho Nacional de Educação;3;GCE;GCE;Grupo GCE § Educação;1;Grupo consultivo especial;Grupo Consultivo Especial;N

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -17,15 +17,15 @@ def stub_match_sigla(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_counter_resets_by_context() -> None:
     records = [
-        {"orgao": "Conselho", "lista": "Lista Única", "tipo": "Titular", "sigla": "mec", "dtmnfr": "2024-01-01"},
-        {"orgao": "Conselho", "lista": "Lista Única", "tipo": "Titular", "sigla": "mec", "dtmnfr": "2024-01-01"},
-        {"orgao": "Conselho", "lista": "Coligação", "tipo": "Titular", "sigla": "mec", "dtmnfr": "2024-01-01"},
-        {"orgao": "Conselho", "lista": "Lista Única", "tipo": "Titular", "sigla": "mec", "dtmnfr": "2024-01-02"},
-        {"orgao": "Conselho", "lista": "Lista Única", "tipo": "Suplente", "sigla": "mec", "dtmnfr": "2024-01-02"},
-        {"orgao": "Conselho", "lista": "Lista Única", "tipo": "Titular", "sigla": "mec", "dtmnfr": "2024-01-01"},
+        {"DTMNFR": "2024-01-01", "ORGAO": "Conselho", "NOME_LISTA": "Lista Única", "TIPO": "Titular", "SIGLA": "mec"},
+        {"DTMNFR": "2024-01-01", "ORGAO": "Conselho", "NOME_LISTA": "Lista Única", "TIPO": "Titular", "SIGLA": "mec"},
+        {"DTMNFR": "2024-01-01", "ORGAO": "Conselho", "NOME_LISTA": "Coligação", "TIPO": "Titular", "SIGLA": "mec"},
+        {"DTMNFR": "2024-01-02", "ORGAO": "Conselho", "NOME_LISTA": "Lista Única", "TIPO": "Titular", "SIGLA": "mec"},
+        {"DTMNFR": "2024-01-02", "ORGAO": "Conselho", "NOME_LISTA": "Lista Única", "TIPO": "Suplente", "SIGLA": "mec"},
+        {"DTMNFR": "2024-01-01", "ORGAO": "Conselho", "NOME_LISTA": "Lista Única", "TIPO": "Titular", "SIGLA": "mec"},
     ]
 
     normalized = normalize.normalize(records)
 
     expected = ["1", "2", "1", "1", "1", "3"]
-    assert [entry["num_ordem"] for entry in normalized] == expected
+    assert [entry["NUM_ORDEM"] for entry in normalized] == expected

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -41,16 +41,14 @@ def test_pipeline_outputs_match_golden(
     counters: dict[tuple[str, str, str, str, str], int] = defaultdict(int)
     for row in actual_rows:
         key = (
-            row.get("dtmnfr", ""),
-            row.get("orgao", "").upper(),
-            row.get("sigla", "").upper(),
-            row.get("lista", "").upper(),
-            row.get("tipo", "").upper(),
+            row.get("DTMNFR", ""),
+            row.get("ORGAO", "").upper(),
+            row.get("SIGLA", "").upper(),
+            row.get("NOME_LISTA", "").upper(),
+            row.get("TIPO", ""),
         )
         counters[key] += 1
-        assert row["num_ordem"] == str(counters[key])
-        counters[row["TIPO"]] += 1
-        assert row["NUM_ORDEM"] == str(counters[row["TIPO"]])
+        assert row["NUM_ORDEM"] == str(counters[key])
 
     preview_path = jobs_module.PROCESSED_DIR / job_id / "preview.json"
     preview = preview_loader(preview_path)

--- a/worker/src/normalize.py
+++ b/worker/src/normalize.py
@@ -3,26 +3,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from typing import Iterable, List, Tuple
-
-from .extract import EXPECTED_COLUMNS
 from .fuzzy import match_sigla
-
-NORMALIZED_COLUMNS = [
-    "orgao",
-    "lista",
-    "tipo",
-    "num_ordem",
-    "linha",
-    "descricao",
-    "valor",
-    "sigla",
-    "fonte",
-    "competencia",
-    "observacao",
-    "dtmnfr",
-    "nome_lista",
-]
-NORMALIZED_COLUMNS = EXPECTED_COLUMNS
 
 
 def _normalize_tipo(value: str) -> str:
@@ -88,57 +69,55 @@ def normalize(records: Iterable[dict[str, str]]) -> List[dict[str, str]]:
     normalized: List[dict[str, str]] = []
     counters: dict[tuple[str, str, str, str, str], int] = defaultdict(int)
     for record in records:
-        data = {column: record.get(column, "").strip() for column in NORMALIZED_COLUMNS}
-        nome_lista = data.get("nome_lista") or data.get("lista", "")
-        data["nome_lista"] = nome_lista
-        tipo = data.get("tipo", "").upper()
-        data["tipo"] = tipo
-        if data["sigla"]:
-            data["sigla"], metadata = match_sigla(data["sigla"])
-            if metadata:
-                data["observacao"] = metadata.get("descricao", data["observacao"])
-        counter_key = (
-            data.get("dtmnfr", ""),
-            data.get("orgao", "").upper(),
-            data.get("sigla", "").upper(),
-            nome_lista.upper(),
-            tipo,
-        )
+        dtmnfr = (record.get("DTMNFR", "") or "").strip()
+        orgao = (record.get("ORGAO", "") or "").strip()
+        raw_tipo = record.get("TIPO", "") or ""
+        tipo = _normalize_tipo(raw_tipo)
+
+        raw_lista = record.get("_raw_lista") or record.get("NOME_LISTA", "")
+        raw_lista = raw_lista.strip()
+        nome_lista_hint = (record.get("NOME_LISTA", "") or "").strip()
+        nome_lista_from_raw, simbolo = _split_lista(raw_lista or nome_lista_hint)
+        nome_lista = nome_lista_hint or nome_lista_from_raw
+
+        independente = _is_independent(raw_lista or nome_lista)
+
+        sigla_value = (record.get("SIGLA", "") or "").strip()
+        sigla_raw = (record.get("_raw_sigla") or sigla_value).strip()
+        partido = (record.get("PARTIDO_PROPONENTE", "") or "").strip()
+        sigla = ""
+        metadata: dict | None = None
+        if sigla_raw:
+            sigla, metadata = match_sigla(sigla_raw)
+        elif sigla_value:
+            sigla, metadata = match_sigla(sigla_value)
+        if metadata:
+            partido = metadata.get("descricao", partido)
+        elif not partido and sigla_raw:
+            partido = sigla_raw.upper()
+        if not sigla:
+            sigla = sigla_raw.upper() if sigla_raw else sigla_value.upper()
+
+        nome_candidato = " ".join((record.get("NOME_CANDIDATO", "") or "").split())
+
+        counter_key = (dtmnfr, orgao.upper(), sigla.upper(), nome_lista.upper(), tipo)
+        num_ordem = ""
         if tipo:
             counters[counter_key] += 1
-            data["num_ordem"] = str(counters[counter_key])
-        else:
-            data["num_ordem"] = data.get("num_ordem", "")
+            num_ordem = str(counters[counter_key])
 
-        raw_lista = record.get("_raw_lista", data.get("NOME_LISTA", ""))
-        nome_lista, simbolo = _split_lista(raw_lista)
-        data["NOME_LISTA"] = nome_lista
-        data["SIMBOLO"] = simbolo
-
-        data["INDEPENDENTE"] = _is_independent(raw_lista)
-
-        tipo_code = _normalize_tipo(record.get("TIPO", ""))
-        data["TIPO"] = tipo_code
-        if tipo_code:
-            counters[tipo_code] += 1
-            data["NUM_ORDEM"] = str(counters[tipo_code])
-        else:
-            data["NUM_ORDEM"] = data.get("NUM_ORDEM", "")
-
-        sigla_raw = record.get("_raw_sigla", data.get("SIGLA", ""))
-        if sigla_raw:
-            matched_sigla, metadata = match_sigla(sigla_raw)
-            data["SIGLA"] = matched_sigla
-            if metadata:
-                data["PARTIDO_PROPONENTE"] = metadata.get(
-                    "descricao", data.get("PARTIDO_PROPONENTE", "")
-                )
-            elif not data.get("PARTIDO_PROPONENTE"):
-                data["PARTIDO_PROPONENTE"] = sigla_raw.upper()
-        else:
-            data["SIGLA"] = ""
-
-        data["NOME_CANDIDATO"] = " ".join(data["NOME_CANDIDATO"].split())
-
-        normalized.append(data)
+        normalized.append(
+            {
+                "DTMNFR": dtmnfr,
+                "ORGAO": orgao,
+                "TIPO": tipo,
+                "SIGLA": sigla,
+                "SIMBOLO": simbolo,
+                "NOME_LISTA": nome_lista,
+                "NUM_ORDEM": num_ordem,
+                "NOME_CANDIDATO": nome_candidato,
+                "PARTIDO_PROPONENTE": partido,
+                "INDEPENDENTE": independente,
+            }
+        )
     return normalized


### PR DESCRIPTION
## Summary
- update the worker extraction pipeline to emit only the 10 contract headers and capture supporting metadata for normalization
- normalize records into the new schema, trim helper fields, and refresh the golden CSV plus tests to validate the new column set

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68e28b0ed7608321b6a2247b9f8e85f6