### PR TITLE
Fix registry CSV parsing delimiter

### DIFF
--- a/api/app/services/jobs.py
+++ b/api/app/services/jobs.py
@@ -176,9 +176,13 @@ class JobService:
 
     def _register_candidate(self, job_id: str, csv_path: Path) -> ModelRecord:
         with csv_path.open(encoding="utf-8") as handle:
-            reader = csv.DictReader(handle)
+            reader = csv.DictReader(handle, delimiter=";")
             rows = list(reader)
-        metrics = {"rows": len(rows), "job_id": job_id}
+        metrics: dict[str, Any] = {"rows": len(rows), "job_id": job_id}
+        if rows:
+            first_row = rows[0]
+            metrics["sample_orgao"] = first_row.get("ORGAO")
+            metrics["sample_tipo"] = first_row.get("TIPO")
         registry = ModelRegistry()
         return registry.register(model_name=f"dataset-{job_id}", metrics=metrics, status="candidate")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -156,6 +156,8 @@ def test_approval_promotes_artifacts(
     assert latest["model_name"] == f"dataset-{job_id}"
     assert latest["status"] == "candidate"
     assert latest["metrics"]["rows"] == len(golden_rows)
+    assert latest["metrics"]["sample_orgao"] == golden_rows[0]["ORGAO"]
+    assert latest["metrics"]["sample_tipo"] == golden_rows[0]["TIPO"]
 
 
 def test_approval_emits_event(


### PR DESCRIPTION
## Summary
- ensure candidate registration reads semicolon-delimited CSVs and capture sample fields in metrics
- extend pipeline approval test to validate recorded registry metrics against expected field values

## Testing
- pytest tests/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_b_68e2a41ebf00832186e911f38bdb3c57