### PR TITLE
Fix Makefile tabs for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ seed:
 	python scripts/seed_master_data.py
 
 develop: seed
-        @echo "Run 'make api', 'make worker' and 'make web' in separate terminals."
+	@echo "Run 'make api', 'make worker' and 'make web' in separate terminals."
 
 test:
-pytest -q
+	pytest -q


### PR DESCRIPTION
## Summary
- replace space-indented Makefile commands with tabs for `develop` and `test`
- ensure `make test` invokes pytest successfully

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_b_68e25d86752c83218e2ceff06b22baf1